### PR TITLE
fix: seperate socket counter function for each thread

### DIFF
--- a/include/multithread.h
+++ b/include/multithread.h
@@ -65,7 +65,7 @@ typedef struct ClientRequest {
 Thread threads[THREAD_NUM];
 extern int next_thread;
 
-void signal_setup(struct event_base * base, struct SignalEvent* signal_event);
+void signal_setup(struct event_base * base, struct SignalEvent* signal_event, int thread_id);
 void start_threads();
 void init_threads();
 void clean_threads();

--- a/include/objects.h
+++ b/include/objects.h
@@ -85,8 +85,11 @@ void activate_client(PgSocket *client);
 void change_client_state(PgSocket *client, SocketState newstate);
 void change_server_state(PgSocket *server, SocketState newstate);
 
-int get_active_client_count(void);
-int get_active_server_count(void);
+int get_active_client_count(int thread_id);
+int get_active_server_count(int thread_id);
+
+int get_total_active_client_count(void);
+int get_total_active_server_count(void);
 
 void tag_pool_dirty(PgPool *pool);
 void tag_database_dirty(PgDatabase *db);

--- a/src/client.c
+++ b/src/client.c
@@ -1001,8 +1001,8 @@ static bool decide_startup_pool(PgSocket *client, PktHdr *pkt)
 
 	/* check if limit allows, don't limit admin db
 	   nb: new incoming conn will be attached to PgSocket, thus
-	   get_active_client_count() counts it */
-	if (get_active_client_count() > cf_max_client_conn) {
+	   get_total_active_client_count() counts it */
+	if (get_total_active_client_count() > cf_max_client_conn) {
 		if (strcmp(dbname, "pgbouncer") != 0) {
 			disconnect_client(client, true, "no more connections allowed (max_client_conn)");
 			return false;

--- a/src/janitor.c
+++ b/src/janitor.c
@@ -800,7 +800,7 @@ static void do_full_maint(evutil_socket_t sock, short flags, void *arg)
 
 	cleanup_client_logins();
 
-	if (cf_shutdown == SHUTDOWN_WAIT_FOR_SERVERS && get_active_server_count() == 0) {
+	if (cf_shutdown == SHUTDOWN_WAIT_FOR_SERVERS && get_active_server_count(this_thread->thread_id) == 0) {
 		log_info("server connections dropped, exiting");
 		cf_shutdown = SHUTDOWN_IMMEDIATE;
 		struct event_base * base = (struct event_base *)pthread_getspecific(event_base_key);
@@ -808,7 +808,7 @@ static void do_full_maint(evutil_socket_t sock, short flags, void *arg)
 		return;
 	}
 
-	if (cf_shutdown == SHUTDOWN_WAIT_FOR_CLIENTS && get_active_client_count() == 0) {
+	if (cf_shutdown == SHUTDOWN_WAIT_FOR_CLIENTS && get_active_client_count(this_thread->thread_id) == 0) {
 		log_info("client connections dropped, exiting");
 		cf_shutdown = SHUTDOWN_IMMEDIATE;
 		struct event_base * base = (struct event_base *)pthread_getspecific(event_base_key);

--- a/src/main.c
+++ b/src/main.c
@@ -969,7 +969,7 @@ int main(int argc, char *argv[])
 		 tls_backend_version());
 
 	sd_notify(0, "READY=1");
-	signal_setup(pgb_event_base, &main_signal_event);
+	signal_setup(pgb_event_base, &main_signal_event, -1);
 	start_threads();
 	pooler_setup();
 	void* retval = NULL;

--- a/src/multithread.c
+++ b/src/multithread.c
@@ -113,7 +113,7 @@ static void handle_sighup(int sock, short flags, void *arg)
 #endif
 
 
-void signal_setup(struct event_base * base, struct SignalEvent* signal_event)
+void signal_setup(struct event_base * base, struct SignalEvent* signal_event, int thread_id)
 {
 	int err;
 
@@ -176,7 +176,7 @@ void* worker_func(void* arg){
 
 	admin_setup();
     thread_pooler_setup();
-	signal_setup(base, &(this_thread->signal_event));
+	signal_setup(base, &(this_thread->signal_event), this_thread->thread_id);
 	janitor_setup();
 	stats_setup();
 

--- a/src/objects.c
+++ b/src/objects.c
@@ -72,8 +72,18 @@ const char *replication_type_parameters[] = {
 	[REPLICATION_PHYSICAL] = "yes",
 };
 
+int get_active_client_count(int thread_id)
+{
+	return slab_active_count(threads[thread_id].client_cache);
+}
+
+int get_active_server_count(int thread_id)
+{
+	return slab_active_count(threads[thread_id].server_cache);
+}
+
 /* fast way to get number of active clients */
-int get_active_client_count(void)
+int get_total_active_client_count(void)
 {
 	int total_count_from_all_threads = 0;
 	for (int i = 0; i < THREAD_NUM; i++) {
@@ -83,7 +93,7 @@ int get_active_client_count(void)
 }
 
 /* fast way to get number of active servers */
-int get_active_server_count(void)
+int get_total_active_server_count(void)
 {
 	int total_count_from_all_threads = 0;
 	for (int i = 0; i < THREAD_NUM; i++) {

--- a/src/pooler.c
+++ b/src/pooler.c
@@ -65,13 +65,15 @@ void cleanup_sockets(void)
 	struct ListenSocket *ls;
 	struct List *el;
 
+	Thread* this_thread = (Thread*) pthread_getspecific(thread_pointer);
+
 	/* avoid cleanup if exit() while suspended */
 	if (cf_pause_mode == P_SUSPEND)
 		return;
 	while ((el = statlist_pop(&sock_list)) != NULL) {
 		ls = container_of(el, struct ListenSocket, node);
 		if (event_del(&ls->ev) < 0) {
-			log_warning("cleanup_sockets, event_del: %s", strerror(errno));
+			log_warning("[Thread %ld] cleanup_sockets: event_del failed: %s", this_thread->thread_id, strerror(errno));
 		}
 		if (ls->fd > 0) {
 			safe_close(ls->fd);


### PR DESCRIPTION
### Summary
This PR tries to fix sigint doesn't trigger pgbouncer to exit, which turns out that it's because the counter loops over all threads instead of the single one to count socket number, resulting in the killer function hangs there. 
