### PR TITLE
fix: multithread event signal handling

### DIFF
--- a/include/multithread.h
+++ b/include/multithread.h
@@ -34,7 +34,6 @@ typedef struct SignalEvent{
 
 typedef struct Thread {
 
-    struct StatList sock_list;
     pthread_t worker;
     int thread_id;
     struct event full_maint_ev;

--- a/src/main.c
+++ b/src/main.c
@@ -80,6 +80,7 @@ struct SignalEvent main_signal_event;
  */
 
 int cf_daemon;
+// TODO(beihao): atomic write if multiple admins change it
 int cf_pause_mode = P_NONE;
 int cf_shutdown = SHUTDOWN_NONE;
 int cf_reboot;


### PR DESCRIPTION
### Summary
* Assign events to main and child threads separately

Heads-up: `cf_pause_mode` receives write operations from admin, from which has race conditions if we have multiple admin sockets on different threads. 